### PR TITLE
corrected duration parsing

### DIFF
--- a/Waveform.php
+++ b/Waveform.php
@@ -60,7 +60,7 @@ class Waveform
 		}
 		
 		if ($this->samples && $this->sampleRate) {
-			$this->duration = 1.0 * $this->samples / $this->samples;
+			$this->duration = 1.0 * $this->samples / $this->sampleRate;
 		}
 		
 		if ($ret !== 0) {


### PR DESCRIPTION
The result of `getDuration()` was always `1.0` because of a small calculation error. If `samples` is divided by `sampleRate`, the result of `getDuration()` works as expected.